### PR TITLE
Trocar o `vue-convenia-util` pelo `brazilian-values`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 The vuetify-mask-br was born to format v-text-field into several br masks. But you can use it in any another component, the directives changes v-model by manipulate vnode.context. If want use this approach, fell free to apply in custom directives.
 
 ## install
-```
+```sh
 npm install vuetify-masks-br --save
 ```
 
 ## algoritm to manipulate model value from directive
-```
+```js
 /**
  * Directive manipulate v-model (must be an object)
  */
@@ -22,12 +22,12 @@ export const {
         }
         //get level of v-model object 
         else {
-			levels.reduce((obj, key) => {
+            levels.reduce((obj, key) => {
                 //apply change in v-model here
-				if (key === levels[levels.length - 1]) obj[key] = obj[key]
-				return obj[key]
-			}, vnode.context)
-        }        
+                if (key === levels[levels.length - 1]) obj[key] = obj[key]
+                return obj[key]
+            }, vnode.context)
+        }
     }
 }
 ```
@@ -43,9 +43,9 @@ $ npm install @vue/cli -g
 ```
 
 ## how to use
-```
-/* main.js */
-import { trim, cnpjcpf, cnpj, cpf, rg, phone, cep } from './../index'
+```js
+// main.js
+import { trim, cnpjcpf, cnpj, cpf, rg, phone, cep } from 'vuetify-masks-br'
 
 Vue.directive('rg', rg)
 Vue.directive('cpf', cpf)
@@ -58,9 +58,10 @@ Vue.directive('cnpjcpf', cnpjcpf)
 new Vue({
   render: h => h(App)
 }).$mount('#app')
+```
 
-
-/* App.vue */
+```vue
+<!-- App.vue -->
 <template>
     <v-text-field
         label="CNPJ/CPF"
@@ -71,8 +72,8 @@ new Vue({
 </template>
 
 <script>
-    import { isCPF, isCNPJ } from '../node_modules/vue-convenia-util/src/validators'
-    
+    import { isCPF, isCNPJ } from 'vuetify-masks-br'
+
     export default {
         data () {
             return {

--- a/index.js
+++ b/index.js
@@ -1,52 +1,19 @@
-import { is } from './node_modules/vue-convenia-util/src/validators'
-import { replace } from './node_modules/vue-convenia-util/src/helpers'
-import Util from 'vue-convenia-util'
+import { formatToCEP, formatToCNPJ, formatToCPF, formatToPhone, formatToRG } from 'brazilian-values';
+
+const mapToNumeric = (value) => value.replace(/\D/g, '')
 
 /*################# custom formatters ####################*/
-const toCNPJ = (cnpj) => {
-    const isValid = is(cnpj, 'String')
-    const formatted = !isValid ? null : replace(cnpj, [
-        [/\D/g, ''],
-        [/(\d{2})(\d)/, '$1.$2'],
-        [/(\d{3})(\d)/, '$1.$2'],
-        [/(\d{3})(\d)/, '$1$2'],
-        [/(\d{4})(\d{1,2})$/, '/$1-$2']
-    ])
-    return formatted
+const formatToCPFCNPJ = (value) => {
+    if (typeof value !== 'string')
+        return null
+
+    const isCNPJ = mapToNumeric(value).length > 11
+
+    if (isCNPJ)
+        return formatToCNPJ(value)
+    return formatToCPF(value)
 }
 
-const toCPFCNPJ = (cpfcnpj) => {
-    const isValid = is(cpfcnpj, 'String')
-    
-    const cnpj = [
-        [/\D/g, ''],
-        [/(\d{2})(\d)/, '$1.$2'],
-        [/(\d{3})(\d)/, '$1.$2'],
-        [/(\d{3})(\d)/, '$1$2'],
-        [/(\d{4})(\d{1,2})$/, '/$1-$2']
-    ]
-
-    const cpf = [
-        [/\D/g, ''],
-        [/(\d{3})(\d)/, '$1.$2'],
-        [/(\d{3})(\d)/, '$1.$2'],
-        [/(\d{3})(\d{1,2})$/, '$1-$2']
-    ]
-
-    const formatted = !isValid ? null : replace(cpfcnpj, cpfcnpj.replace(/[/.]/g, '').length > 12 ? cnpj : cpf)
-
-    return formatted
-}
-
-const toCEP = (value) => {
-    const isValid = is(value, 'String')
-    const formatted = !isValid ? null : replace(value, [
-        [/\D/g, ''],
-        [/(\d{2})(\d)/, '$1.$2'],
-        [/(\d{3})(\d{1,3})/, '$1-$2']
-    ])
-    return formatted
-}
 /*################## direcitves ####################*/
 const trim = {
     update (el, binding, vnode) {
@@ -66,13 +33,13 @@ const rg = {
     bind(el) {
         el.getElementsByTagName('input')[0].setAttribute('maxlength', 12)
     },
-    update (el, binding, vnode) {
+    update (el, binding, vnode){
         const levels = binding.expression.split('.')
         if (levels.length === 1) {
-            vnode.context[levels[0]] = Util.format.toRG(vnode.context[levels[0]])
+            vnode.context[levels[0]] = formatToRG(vnode.context[levels[0]], 'SP')
         } else {
             levels.reduce((obj, key) => {
-                if (key === levels[levels.length - 1]) obj[key] = Util.format.toRG(obj[key])
+                if (key === levels[levels.length - 1]) obj[key] = formatToRG(obj[key], 'SP')
                 return obj[key]
             }, vnode.context)
         }
@@ -86,10 +53,10 @@ const phone = {
     update (el, binding, vnode) {
         const levels = binding.expression.split('.')
         if (levels.length === 1) {
-            vnode.context[levels[0]] = Util.format.toPhone(vnode.context[levels[0]])
+            vnode.context[levels[0]] = formatToPhone(vnode.context[levels[0]])
         } else {
             levels.reduce((obj, key) => {
-                if (key === levels[levels.length - 1]) obj[key] = Util.format.toPhone(obj[key])
+                if (key === levels[levels.length - 1]) obj[key] = formatToPhone(obj[key])
                 return obj[key]
             }, vnode.context)
         }
@@ -103,10 +70,10 @@ const cpf =  {
     update (el, binding, vnode) {
         const levels = binding.expression.split('.')
         if (levels.length === 1) {
-            vnode.context[levels[0]] = Util.format.toCPF(vnode.context[levels[0]])
+            vnode.context[levels[0]] = formatToCPF(vnode.context[levels[0]])
         } else {
             levels.reduce((obj, key) => {
-                if (key === levels[levels.length - 1]) obj[key] = Util.format.toCPF(obj[key])
+                if (key === levels[levels.length - 1]) obj[key] = formatToCPF(obj[key])
                 return obj[key]
             }, vnode.context)
         }
@@ -120,10 +87,10 @@ const cnpj = {
     update (el, binding, vnode) {
         const levels = binding.expression.split('.')
         if (levels.length === 1) {
-            vnode.context[levels[0]] = toCNPJ(vnode.context[levels[0]])
+            vnode.context[levels[0]] = formatToCNPJ(vnode.context[levels[0]])
         } else {
             levels.reduce((obj, key) => {
-                if (key === levels[levels.length - 1]) obj[key] = toCNPJ(obj[key])
+                if (key === levels[levels.length - 1]) obj[key] = formatToCNPJ(obj[key])
                 return obj[key]
             }, vnode.context)
         }
@@ -136,11 +103,12 @@ const cnpjcpf = {
     },
     update (el, binding, vnode) {
         const levels = binding.expression.split('.')
+        console.log(levels)
         if (levels.length === 1) {
-            vnode.context[levels[0]] = toCPFCNPJ(vnode.context[levels[0]])
+            vnode.context[levels[0]] = formatToCPFCNPJ(vnode.context[levels[0]])
         } else {
             levels.reduce((obj, key) => {
-                if (key === levels[levels.length - 1]) obj[key] = toCPFCNPJ(obj[key])
+                if (key === levels[levels.length - 1]) obj[key] = formatToCPFCNPJ(obj[key])
                 return obj[key]
             }, vnode.context)
         }
@@ -154,14 +122,16 @@ const cep = {
     update (el, binding, vnode) {
         const levels = binding.expression.split('.')
         if (levels.length === 1) {
-            vnode.context[levels[0]] = toCEP(vnode.context[levels[0]])
+            vnode.context[levels[0]] = formatToCEP(vnode.context[levels[0]])
         } else {
             levels.reduce((obj, key) => {
-                if (key === levels[levels.length - 1]) obj[key] = toCEP(obj[key])
+                if (key === levels[levels.length - 1]) obj[key] = formatToCEP(obj[key])
                 return obj[key]
             }, vnode.context)
         }
     }
 }
+
+export { isCNPJ, isCPF } from 'brazilian-values'
 
 export { trim, rg, phone, cpf, cnpj, cnpjcpf, cep }

--- a/index.js
+++ b/index.js
@@ -6,11 +6,11 @@ import Util from 'vue-convenia-util'
 const toCNPJ = (cnpj) => {
     const isValid = is(cnpj, 'String')
     const formatted = !isValid ? null : replace(cnpj, [
-      [/\D/g, ''],
-      [/(\d{2})(\d)/, '$1.$2'],
-      [/(\d{3})(\d)/, '$1.$2'],
-      [/(\d{3})(\d)/, '$1$2'],
-      [/(\d{4})(\d{1,2})$/, '/$1-$2']
+        [/\D/g, ''],
+        [/(\d{2})(\d)/, '$1.$2'],
+        [/(\d{3})(\d)/, '$1.$2'],
+        [/(\d{3})(\d)/, '$1$2'],
+        [/(\d{4})(\d{1,2})$/, '/$1-$2']
     ])
     return formatted
 }
@@ -41,9 +41,9 @@ const toCPFCNPJ = (cpfcnpj) => {
 const toCEP = (value) => {
     const isValid = is(value, 'String')
     const formatted = !isValid ? null : replace(value, [
-      [/\D/g, ''],
-      [/(\d{2})(\d)/, '$1.$2'],
-      [/(\d{3})(\d{1,3})/, '$1-$2']
+        [/\D/g, ''],
+        [/(\d{2})(\d)/, '$1.$2'],
+        [/(\d{3})(\d{1,3})/, '$1-$2']
     ])
     return formatted
 }
@@ -54,10 +54,10 @@ const trim = {
         if (levels.length === 1) {
             vnode.context[levels[0]] = vnode.context[levels[0]].replace(/\s/g, "")
         } else {
-			levels.reduce((obj, key) => {
-				if (key === levels[levels.length - 1]) obj[key] = obj[key].replace(/\s/g, "")
-				return obj[key]
-			}, vnode.context)
+            levels.reduce((obj, key) => {
+                if (key === levels[levels.length - 1]) obj[key] = obj[key].replace(/\s/g, "")
+                return obj[key]
+            }, vnode.context)
         }        
     }
 }
@@ -71,10 +71,10 @@ const rg = {
         if (levels.length === 1) {
             vnode.context[levels[0]] = Util.format.toRG(vnode.context[levels[0]])
         } else {
-			levels.reduce((obj, key) => {
-				if (key === levels[levels.length - 1]) obj[key] = Util.format.toRG(obj[key])
-				return obj[key]
-			}, vnode.context)
+            levels.reduce((obj, key) => {
+                if (key === levels[levels.length - 1]) obj[key] = Util.format.toRG(obj[key])
+                return obj[key]
+            }, vnode.context)
         }
     }
 }
@@ -88,10 +88,10 @@ const phone = {
         if (levels.length === 1) {
             vnode.context[levels[0]] = Util.format.toPhone(vnode.context[levels[0]])
         } else {
-			levels.reduce((obj, key) => {
-				if (key === levels[levels.length - 1]) obj[key] = Util.format.toPhone(obj[key])
-				return obj[key]
-			}, vnode.context)
+            levels.reduce((obj, key) => {
+                if (key === levels[levels.length - 1]) obj[key] = Util.format.toPhone(obj[key])
+                return obj[key]
+            }, vnode.context)
         }
     }
 }
@@ -105,10 +105,10 @@ const cpf =  {
         if (levels.length === 1) {
             vnode.context[levels[0]] = Util.format.toCPF(vnode.context[levels[0]])
         } else {
-			levels.reduce((obj, key) => {
-				if (key === levels[levels.length - 1]) obj[key] = Util.format.toCPF(obj[key])
-				return obj[key]
-			}, vnode.context)
+            levels.reduce((obj, key) => {
+                if (key === levels[levels.length - 1]) obj[key] = Util.format.toCPF(obj[key])
+                return obj[key]
+            }, vnode.context)
         }
     }
 }
@@ -122,10 +122,10 @@ const cnpj = {
         if (levels.length === 1) {
             vnode.context[levels[0]] = toCNPJ(vnode.context[levels[0]])
         } else {
-			levels.reduce((obj, key) => {
-				if (key === levels[levels.length - 1]) obj[key] = toCNPJ(obj[key])
-				return obj[key]
-			}, vnode.context)
+            levels.reduce((obj, key) => {
+                if (key === levels[levels.length - 1]) obj[key] = toCNPJ(obj[key])
+                return obj[key]
+            }, vnode.context)
         }
     }
 }
@@ -139,10 +139,10 @@ const cnpjcpf = {
         if (levels.length === 1) {
             vnode.context[levels[0]] = toCPFCNPJ(vnode.context[levels[0]])
         } else {
-			levels.reduce((obj, key) => {
-				if (key === levels[levels.length - 1]) obj[key] = toCPFCNPJ(obj[key])
-				return obj[key]
-			}, vnode.context)
+            levels.reduce((obj, key) => {
+                if (key === levels[levels.length - 1]) obj[key] = toCPFCNPJ(obj[key])
+                return obj[key]
+            }, vnode.context)
         }
     }
 }
@@ -156,10 +156,10 @@ const cep = {
         if (levels.length === 1) {
             vnode.context[levels[0]] = toCEP(vnode.context[levels[0]])
         } else {
-			levels.reduce((obj, key) => {
-				if (key === levels[levels.length - 1]) obj[key] = toCEP(obj[key])
-				return obj[key]
-			}, vnode.context)
+            levels.reduce((obj, key) => {
+                if (key === levels[levels.length - 1]) obj[key] = toCEP(obj[key])
+                return obj[key]
+            }, vnode.context)
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
+    "brazilian-values": "^0.1.0",
     "moment": "2.22.2",
     "vue": "^2.5.17",
-    "vue-convenia-util": "0.7.1",
     "vuetify": "1.0.19"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "moment": "2.22.2",
-    "vue": "2.5.16",
+    "vue": "^2.5.17",
     "vue-convenia-util": "0.7.1",
     "vuetify": "1.0.19"
   },
@@ -29,11 +29,11 @@
     "@babel/polyfill": "^7.0.0-beta.49",
     "@vue/cli-plugin-babel": "^3.0.0-rc.5",
     "@vue/cli-plugin-eslint": "^3.0.0-rc.5",
-    "@vue/cli-service": "^3.0.0-rc.5",
     "@vue/cli-plugin-unit-mocha": "^3.0.0-rc.5",
+    "@vue/cli-service": "^3.0.0-rc.5",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
     "vue-cli-plugin-vuetify": "^0.1.6",
-    "vue-template-compiler": "^2.5.16"
+    "vue-template-compiler": "^2.5.17"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -90,7 +90,7 @@
 </template>
 
 <script>
-  import { isCPF, isCNPJ } from '../node_modules/vue-convenia-util/src/validators'
+  import { isCPF, isCNPJ } from '../'
 
   export default {
     name: 'App',

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import './plugins/vuetify'
 
 import Vue from 'vue'
 import App from './App.vue'
-import { trim, cnpjcpf, cnpj, cpf, rg, phone, cep } from './../index'
+import { trim, cnpjcpf, cnpj, cpf, rg, phone, cep } from '../'
 
 Vue.config.productionTip = false
 


### PR DESCRIPTION
Opa, beleza?

Eu sou o criador e antigo mantenedor do `vue-convenia-util`, e essa PR remove ele e adiciona o `brazilian-values` no lugar.

## Motivos

O `vue-convenia-util` não parece ser mais mantido desde que saí da Convenia e o `brazilian-values` é o sucessor espiritual dele rs.

O `brazilian-values` não tem dependências e é bem menor, como você pode ver comparando os tamanhos deles no link abaixo:
https://bundlephobia.com/result?p=vue-convenia-util@0.7.1
https://bundlephobia.com/result?p=brazilian-values@0.1.0

O `brazilian-values` é escrito em TypeScript e provê intellisense pra JavaScript também.

## Outras alterações

- Consertei a indentação que não estava consistente nos arquivos
- Exportei as validações `isCNPJ`, `isCPF` no seu indíce e que consumir sua biblioteca não precisa importar essas duas funções do `node_modules`
- Consertei a sintaxe de cores de README